### PR TITLE
Add dev script for package development

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"format": "prettier --write package.json .prettierrc .vscode .eslintrc.cjs e2e .github *.md",
 		"format:check": "prettier --check package.json .prettierrc .vscode .eslintrc.cjs .github *.md",
 		"check-deps": "tsx scripts/check-deps.ts",
-		"dev": "pnpm --filter \"$npm_config_filter\" run dev || echo \"To start development server, specify the package using --filter option. Example: npm run dev --filter=@huggingface/inference\""
+		"dev": "npx pnpm --filter \"$npm_config_filter\" run dev || echo \"To start development server, specify the package using --filter option. Example: npm run dev --filter=@huggingface/inference\""
 	},
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"format": "prettier --write package.json .prettierrc .vscode .eslintrc.cjs e2e .github *.md",
 		"format:check": "prettier --check package.json .prettierrc .vscode .eslintrc.cjs .github *.md",
 		"check-deps": "tsx scripts/check-deps.ts",
-		"dev": "node -e \"if (process.env.npm_config_filter) { require('child_process').execSync('npx pnpm --filter ' + process.env.npm_config_filter + ' run dev', {stdio: 'inherit'}); } else { console.log('To start development server, specify the package using --filter option.\\nExample: npm run dev --filter=@huggingface/inference'); }\""
+		"dev": "node scripts/run-dev.js"
 	},
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"format": "prettier --write package.json .prettierrc .vscode .eslintrc.cjs e2e .github *.md",
 		"format:check": "prettier --check package.json .prettierrc .vscode .eslintrc.cjs .github *.md",
 		"check-deps": "tsx scripts/check-deps.ts",
-		"dev": "npx pnpm --filter \"$npm_config_filter\" run dev || echo \"To start development server, specify the package using --filter option. Example: npm run dev --filter=@huggingface/inference\""
+		"dev": "node -e \"if (process.env.npm_config_filter) { require('child_process').execSync('npx pnpm --filter ' + process.env.npm_config_filter + ' run dev', {stdio: 'inherit'}); } else { console.log('To start development server, specify the package using --filter option.\\nExample: npm run dev --filter=@huggingface/inference'); }\""
 	},
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"lint:check": "eslint --ext .cjs,.ts .eslintrc.cjs",
 		"format": "prettier --write package.json .prettierrc .vscode .eslintrc.cjs e2e .github *.md",
 		"format:check": "prettier --check package.json .prettierrc .vscode .eslintrc.cjs .github *.md",
-		"check-deps": "tsx scripts/check-deps.ts"
+		"check-deps": "tsx scripts/check-deps.ts",
+		"dev": "pnpm --filter \"$npm_config_filter\" run dev || echo \"To start development server, specify the package using --filter option. Example: npm run dev --filter=@huggingface/inference\""
 	},
 	"devDependencies": {
 		"@typescript-eslint/eslint-plugin": "^7.2.0",

--- a/scripts/run-dev.js
+++ b/scripts/run-dev.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+// Get the package name from command line args
+const args = process.argv.slice(2);
+const packageArg = args.find((arg) => !arg.startsWith("-"));
+
+if (!packageArg) {
+	console.log("To start development server, specify the package name as an argument.");
+	console.log("Example: npm run dev inference");
+	console.log("\nAvailable packages:");
+
+	// List available packages from the packages directory
+	const packagesDir = path.join(__dirname, "..", "packages");
+	const packages = fs
+		.readdirSync(packagesDir)
+		.filter(
+			(dir) =>
+				fs.statSync(path.join(packagesDir, dir)).isDirectory() &&
+				fs.existsSync(path.join(packagesDir, dir, "package.json"))
+		);
+
+	packages.forEach((pkg) => {
+		try {
+			const pkgJson = JSON.parse(fs.readFileSync(path.join(packagesDir, pkg, "package.json"), "utf8"));
+			const hasDevScript = pkgJson.scripts && pkgJson.scripts.dev;
+			console.log(`- ${pkg}${hasDevScript ? "" : " (no dev script)"}`);
+		} catch (e) {
+			console.log(`- ${pkg} (error reading package.json)`);
+		}
+	});
+
+	process.exit(0);
+}
+
+// Normalize package name
+let packageName = packageArg;
+if (!packageName.startsWith("@huggingface/")) {
+	packageName = `@huggingface/${packageName}`;
+}
+
+try {
+	console.log(`Starting dev server for package: ${packageName}`);
+	execSync(`npx pnpm --filter ${packageName} run dev`, {
+		stdio: "inherit",
+		env: process.env,
+	});
+} catch (error) {
+	console.error(`\nError running dev server for ${packageName}:`);
+
+	// Check if the package exists
+	const packagesDir = path.join(__dirname, "..", "packages");
+	const shortName = packageName.replace("@huggingface/", "");
+	const packageDir = path.join(packagesDir, shortName);
+
+	if (!fs.existsSync(packageDir)) {
+		console.error(`Package "${shortName}" not found in packages directory.`);
+	} else {
+		// Check if the package has a dev script
+		try {
+			const pkgJson = JSON.parse(fs.readFileSync(path.join(packageDir, "package.json"), "utf8"));
+			if (!pkgJson.scripts || !pkgJson.scripts.dev) {
+				console.error(`Package "${shortName}" exists but doesn't have a dev script.`);
+			} else {
+				console.error("See error details above.");
+			}
+		} catch (e) {
+			console.error(`Error reading package.json for "${shortName}".`);
+		}
+	}
+
+	process.exit(1);
+}


### PR DESCRIPTION
This PR adds a new development workflow to simplify running package dev servers:

- Added a `dev` script to the root package.json
- Created a new `scripts/run-dev.js` utility that:
  - Allows running a specific package's dev server with `npm run dev`
  - Lists all available packages when no package is specified
  - Provides helpful error messages for common issues
  - Automatically normalizes package names to include the @huggingface/ prefix

Usage example: `npm run dev inference`

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=orbit-works&projectId=74221d1bc2144050839ee8dfc930bb72)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>74221d1bc2144050839ee8dfc930bb72</projectId>-->